### PR TITLE
Fix bug: Grace period updated even if it already exists

### DIFF
--- a/scrapers/diffChecker.mjs
+++ b/scrapers/diffChecker.mjs
@@ -53,7 +53,7 @@ export async function integrateCalls(newCalls) {
             resultCalls.push({
                 ...oldCall,
                 active: false,
-                gracePeriod: (new Date(new Date(now).setDate(now.getDate() + 30))).toISOString()
+                gracePeriod: oldCall.gracePeriod ? oldCall.gracePeriod : (new Date(new Date(now).setDate(now.getDate() + 30))).toISOString()
             });
         }
     }


### PR DESCRIPTION
Fixes #34

Update `scrapers/diffChecker.mjs` to avoid updating grace period if already set

* Check if `gracePeriod` is already set before updating it
* Add a condition to only update `gracePeriod` if it is not already set

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/julianprester/calls-for-papers/pull/35?shareId=752ec326-48ae-45f5-b00b-60d0a4d66355).